### PR TITLE
Add workflow to deploy safe-setting to Go1 AKS

### DIFF
--- a/.github/workflows/go1-helm-deploy.yml
+++ b/.github/workflows/go1-helm-deploy.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: azure/setup-kubectl@v3 # default is latest stable
-        # with:
-        #   version: 'latest' # default is latest stable
       - uses: azure/k8s-set-context@v4.0.0
         with:
           method: kubeconfig

--- a/.github/workflows/go1-helm-deploy.yml
+++ b/.github/workflows/go1-helm-deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to Go1 AKS
+on:
+  workflow_dispatch:
+    inputs:
+      status:
+        description: 'Status of the previous workflow'
+        required: true
+        default: 'passed'
+      release:
+        description: 'Release tag from the previous workflow'
+        required: true
+env:
+  KUBECONFIG_CONTENTS: secrets.KUBECONFIG_PRODUCTION_K8S_AU
+  # require envs for safe-settings app https://github.com/github/safe-settings/blob/main-enterprise/docs/deploy.md
+  APP_ID: secrets.APP_ID
+  WEBHOOK_SECRET: secrets.WEBHOOK_SECRET
+  PRIVATE_KEY: secrets.PRIVATE_KEY
+jobs:
+  deploy-to-aks:
+    if: ${{ github.event.inputs.status == 'passed' }}
+    name: Deploy to Kubernetes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: azure/setup-kubectl@v3 # default is latest stable
+        # with:
+        #   version: 'latest' # default is latest stable
+      - uses: azure/k8s-set-context@v4.0.0
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ env.KUBECONFIG_CONTENTS }}
+      - uses: azure/k8s-bake@v3
+        with:
+          renderEngine: 'helm'
+          helmChart: './helm/safe-settings/'
+          overrideFiles: './go1-values-override.yaml'
+          overrides: |
+              image.tag: ${{ github.event.inputs.release }}
+              env.APP_ID: ${{ env.APP_ID }}
+              env.PRIVATE_KEY: ${{ env.PRIVATE_KEY }}
+              env.WEBHOOK_SECRET: ${{ env.WEBHOOK_SECRET }}
+          helm-version: 'latest'
+        id: bake
+      - uses: Azure/k8s-deploy@v1
+        with:
+          manifests: ${{ steps.bake.outputs.manifestsBundle }}
+          images: |
+              ghcr.io/github/safe-settings:${{ github.event.inputs.release }}

--- a/go1-values-override.yaml
+++ b/go1-values-override.yaml
@@ -1,0 +1,18 @@
+deploymentConfig:
+  {}
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: "letsencrypt-cf-prod"
+  hosts:
+    - host: safe-settings.go1.co
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+   - secretName: safe-settings-go1-co-tls
+     hosts:
+       - safe-settings.go1.co


### PR DESCRIPTION
Deploy the safe-setting app to the Go1 AKS cluster.

Currently, the app will monitor https://github.com/organizations/go1com-sbox

<img width="1014" alt="image" src="https://github.com/go1com/safe-settings/assets/128535/0ff48b9f-19c0-401f-8295-0b78b191be77">

<img width="1101" alt="image" src="https://github.com/go1com/safe-settings/assets/128535/2a05df66-9d31-4d10-b930-b56673a68ed4">
